### PR TITLE
Create local-first Workflowy-style outliner MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# outliner-like-workflowy
+# Outline MVP
+
+A local-first outlining app inspired by Workflowy. This MVP is built with React, TypeScript, Zustand, and Vite and stores data in `localStorage` so it works entirely offline.
+
+## Features
+
+- Infinite nested outline with checkbox-based tasks.
+- Keyboard-first controls for adding siblings/children, indenting, moving, and toggling completion or notes.
+- Inline Markdown formatting with bold, italic, and code styling that round-trips via clipboard.
+- Notes per item rendered in lightweight editor surfaces with quick toggles.
+- Undo/redo history with typing coalescing and structural snapshotting.
+- Markdown copy/paste for full subtree export/import.
+- Local persistence with instant restore on reload.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+> **Note:** Package installation requires access to the public npm registry. If your environment blocks registry access, configure npm to use an accessible mirror.
+
+When dependencies are installed, start the dev server with `npm run dev` and open the provided URL in your browser.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| Enter | New sibling |
+| Shift+Enter | Toggle note and focus note |
+| Tab / Shift+Tab | Indent / Outdent |
+| Alt+↑ / Alt+↓ | Move item up/down |
+| Cmd/Ctrl+. | Toggle checkbox |
+| Cmd/Ctrl+; | Toggle note |
+| Cmd/Ctrl+B | Bold selection |
+| Cmd/Ctrl+I | Italic selection |
+| Cmd/Ctrl+` | Inline code |
+| Cmd/Ctrl+Z / Shift+Cmd/Ctrl+Z / Cmd/Ctrl+Y | Undo / Redo |
+| Cmd/Ctrl+C / Cmd/Ctrl+V | Copy / Paste subtree as Markdown |
+
+## Clipboard Format
+
+Copying an item places Markdown of the entire subtree onto the clipboard, e.g.:
+
+```
+- [x] Complete outline
+  - [ ] Polish styling
+    Note for this item
+```
+
+Pasting Markdown with checkboxes reproduces the nested structure in the outline. Non-Markdown text is inserted into the current item.
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Outline</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "outliner-like-workflowy",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "immer": "^10.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+import Outliner from './components/Outliner';
+import { useOutlinerStore } from './store';
+
+const App: React.FC = () => {
+  const undo = useOutlinerStore((state) => state.undo);
+  const redo = useOutlinerStore((state) => state.redo);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if ((event.metaKey || event.ctrlKey) && key === 'z') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+      }
+      if ((event.metaKey || event.ctrlKey) && (key === 'y')) {
+        event.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [redo, undo]);
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Outline</h1>
+        <p className="tagline">Fast, local-first outlining with keyboard superpowers.</p>
+      </header>
+      <main>
+        <Outliner />
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/Outliner.tsx
+++ b/src/components/Outliner.tsx
@@ -1,0 +1,410 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import clsx from 'clsx';
+import { useOutlinerStore } from '../store';
+import { ItemId } from '../types';
+import { renderInlineMarkdown } from '../utils/format';
+import { getCaretOffset, getSelectionOffsets, setCaretOffset } from '../utils/selection';
+import { parseMarkdown, serializeMarkdown, type ParsedNode } from '../utils/markdown';
+
+interface ItemRowProps {
+  id: ItemId;
+  depth: number;
+}
+
+const formatSelection = (
+  value: string,
+  selection: { start: number; end: number },
+  marker: string
+): { text: string; selectionOffset: number } | null => {
+  const { start, end } = selection;
+  if (start === end) return null;
+  const before = value.slice(0, start);
+  const middle = value.slice(start, end);
+  const after = value.slice(end);
+  const markerPair = marker === '`' ? '`' : marker;
+  return {
+    text: `${before}${marker}${middle}${markerPair}${after}`,
+    selectionOffset: end + marker.length + markerPair.length,
+  };
+};
+
+const ItemRow: React.FC<ItemRowProps> = ({ id, depth }) => {
+  const item = useOutlinerStore((state) => state.doc.items[id]);
+  const collapsed = useOutlinerStore((state) => Boolean(state.ui.collapsed[id]));
+  const noteOpen = useOutlinerStore((state) => state.ui.notesOpen[id] ?? Boolean(state.doc.items[id].note));
+  const selection = useOutlinerStore((state) => state.ui.selection);
+  const focusItem = useOutlinerStore((state) => state.focusItem);
+  const toggleCollapse = useOutlinerStore((state) => state.toggleCollapse);
+  const toggleCollapseDeep = useOutlinerStore((state) => state.toggleCollapseDeep);
+  const toggleChecked = useOutlinerStore((state) => state.toggleChecked);
+  const toggleNote = useOutlinerStore((state) => state.toggleNote);
+  const setText = useOutlinerStore((state) => state.setText);
+  const setNote = useOutlinerStore((state) => state.setNote);
+  const addSiblingAfter = useOutlinerStore((state) => state.addSiblingAfter);
+  const addChild = useOutlinerStore((state) => state.addChild);
+  const deleteItem = useOutlinerStore((state) => state.deleteItem);
+  const moveUp = useOutlinerStore((state) => state.moveUp);
+  const moveDown = useOutlinerStore((state) => state.moveDown);
+  const indent = useOutlinerStore((state) => state.indent);
+  const outdent = useOutlinerStore((state) => state.outdent);
+  const insertNodes = useOutlinerStore((state) => state.insertNodes);
+
+  const textRef = useRef<HTMLDivElement>(null);
+  const noteRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!textRef.current) return;
+    textRef.current.innerHTML = renderInlineMarkdown(item.text);
+  }, [item.text]);
+
+  useEffect(() => {
+    if (!textRef.current) return;
+    if (selection?.anchorId === id && selection.mode === 'caret') {
+      textRef.current.focus();
+      if (selection.caretOffset !== undefined) {
+        setCaretOffset(textRef.current, selection.caretOffset);
+      }
+    }
+  }, [selection, id]);
+
+  const updateCaret = useCallback(() => {
+    if (!textRef.current) return;
+    const caret = getCaretOffset(textRef.current);
+    focusItem(id, caret, 'caret');
+  }, [focusItem, id]);
+
+  const handleInput = useCallback(() => {
+    if (!textRef.current) return;
+    const text = textRef.current.innerText;
+    const caret = getCaretOffset(textRef.current);
+    setText(id, text, { typing: true, caretOffset: caret });
+  }, [id, setText]);
+
+  const applyFormatting = useCallback(
+    (marker: string) => {
+      if (!textRef.current) return;
+      let offsets = getSelectionOffsets(textRef.current);
+      if (!offsets || offsets.start === offsets.end) {
+        if (!item.text.length) return;
+        offsets = { start: 0, end: item.text.length };
+      }
+      const formatted = formatSelection(item.text, offsets, marker);
+      if (formatted) {
+        setText(id, formatted.text, { caretOffset: formatted.selectionOffset });
+        requestAnimationFrame(() => {
+          if (textRef.current) {
+            setCaretOffset(textRef.current, formatted.selectionOffset);
+          }
+        });
+      }
+    },
+    [id, item.text, setText]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          if (!noteOpen) {
+            toggleNote(id);
+          }
+          const store = useOutlinerStore.getState();
+          const existing = store.doc.items[id].note ?? '';
+          const nextValue = existing ? `${existing}\n` : '';
+          if (nextValue !== existing) {
+            setNote(id, nextValue);
+          }
+          requestAnimationFrame(() => {
+            if (noteRef.current) {
+              noteRef.current.focus();
+              const length = noteRef.current.value.length;
+              noteRef.current.setSelectionRange(length, length);
+            }
+          });
+          return;
+        }
+        const newId = addSiblingAfter(id);
+        requestAnimationFrame(() => focusItem(newId, 0, 'caret'));
+        return;
+      }
+      if (event.key === 'Tab') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          outdent(id);
+        } else {
+          indent(id);
+        }
+        return;
+      }
+      if (event.key === 'Backspace') {
+        if (textRef.current && textRef.current.innerText.trim().length === 0 && item.children.length === 0) {
+          event.preventDefault();
+          const store = useOutlinerStore.getState();
+          const doc = store.doc;
+          const current = doc.items[id];
+          let targetId: ItemId | undefined;
+          const seekLastDescendant = (startId: ItemId): ItemId => {
+            let currentId = startId;
+            while (doc.items[currentId].children.length) {
+              const children = doc.items[currentId].children;
+              currentId = children[children.length - 1];
+            }
+            return currentId;
+          };
+          if (current.parentId) {
+            const siblings = doc.items[current.parentId].children;
+            const idx = siblings.indexOf(id);
+            if (idx > 0) {
+              targetId = seekLastDescendant(siblings[idx - 1]);
+            } else {
+              targetId = current.parentId;
+            }
+          } else {
+            const roots = doc.rootIds;
+            const idx = roots.indexOf(id);
+            if (idx > 0) {
+              targetId = seekLastDescendant(roots[idx - 1]);
+            }
+          }
+          const caretLength = targetId ? doc.items[targetId]?.text.length ?? 0 : 0;
+          deleteItem(id);
+          if (targetId) {
+            requestAnimationFrame(() => focusItem(targetId, caretLength, 'caret'));
+          }
+        }
+        return;
+      }
+      if (event.key === 'ArrowUp' && event.altKey) {
+        event.preventDefault();
+        moveUp(id);
+        return;
+      }
+      if (event.key === 'ArrowDown' && event.altKey) {
+        event.preventDefault();
+        moveDown(id);
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'b') {
+        event.preventDefault();
+        applyFormatting('**');
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'i') {
+        event.preventDefault();
+        applyFormatting('*');
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key === '`') {
+        event.preventDefault();
+        applyFormatting('`');
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key === '.') {
+        event.preventDefault();
+        toggleChecked(id);
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key === ';') {
+        event.preventDefault();
+        toggleNote(id);
+        requestAnimationFrame(() => noteRef.current?.focus());
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && (event.key.toLowerCase() === 'c' || event.key.toLowerCase() === 'x')) {
+        // rely on onCopy handler
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'v') {
+        // rely on onPaste handler
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'd') {
+        event.preventDefault();
+        addSiblingAfter(id);
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'z') {
+        event.preventDefault();
+      }
+    },
+    [
+      addSiblingAfter,
+      focusItem,
+      id,
+      indent,
+      item.text,
+      moveDown,
+      moveUp,
+      noteOpen,
+      outdent,
+      applyFormatting,
+      deleteItem,
+      setNote,
+      setText,
+      toggleChecked,
+      toggleNote,
+    ]
+  );
+
+  const handleCopy = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const markdown = serializeMarkdown(useOutlinerStore.getState().doc, id);
+      event.clipboardData.setData('text/plain', markdown);
+      event.clipboardData.setData('text/markdown', markdown);
+    },
+    [id]
+  );
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      const clipboardData = event.clipboardData.getData('text/markdown') || event.clipboardData.getData('text/plain');
+      if (!clipboardData) return;
+      const parsed = parseMarkdown(clipboardData);
+      if (!parsed.length) return;
+      event.preventDefault();
+      const mode = selection?.mode;
+      if (mode === 'subtree') {
+        const lastChild = item.children[item.children.length - 1];
+        insertNodes(id, lastChild, parsed);
+      } else {
+        insertNodes(item.parentId, id, parsed);
+      }
+    },
+    [id, insertNodes, item.children, item.parentId, selection?.mode]
+  );
+
+  const handleNoteChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setNote(id, event.target.value);
+    },
+    [id, setNote]
+  );
+
+  const focusNote = useCallback(() => {
+    focusItem(id, undefined, 'item');
+  }, [focusItem, id]);
+
+  const handleRowFocus = useCallback(() => {
+    focusItem(id, undefined, 'caret');
+  }, [focusItem, id]);
+
+  const handleAddChild = useCallback(() => {
+    const childId = addChild(id);
+    requestAnimationFrame(() => focusItem(childId, 0, 'caret'));
+  }, [addChild, focusItem, id]);
+
+  const handleChevronClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      if (event.altKey) {
+        const newState = !collapsed;
+        toggleCollapseDeep(id, newState);
+      } else {
+        toggleCollapse(id);
+      }
+    },
+    [collapsed, id, toggleCollapse, toggleCollapseDeep]
+  );
+
+  const toolbar = (
+    <div className="item-toolbar">
+      <button onClick={() => moveUp(id)} title="Move up (Alt+↑)">↑</button>
+      <button onClick={() => moveDown(id)} title="Move down (Alt+↓)">↓</button>
+      <button onClick={() => indent(id)} title="Indent (Tab)">→</button>
+      <button onClick={() => outdent(id)} title="Outdent (Shift+Tab)">←</button>
+      <button onClick={() => applyFormatting('**')} title="Bold (Cmd/Ctrl+B)"><strong>B</strong></button>
+      <button onClick={() => applyFormatting('*')} title="Italic (Cmd/Ctrl+I)"><em>I</em></button>
+      <button onClick={() => applyFormatting('`')} title="Code (Cmd/Ctrl+`)"><code>{'<'}</code></button>
+      <button onClick={handleAddChild} title="Add child">+</button>
+      <button onClick={() => toggleNote(id)} title="Toggle note (Cmd/Ctrl+;)">📝</button>
+      <button onClick={() => deleteItem(id)} title="Delete">✕</button>
+    </div>
+  );
+
+  return (
+    <div className="item-container" style={{ marginLeft: depth * 20 }}>
+      <div className={clsx('item-row', { active: selection?.anchorId === id })} onClick={handleRowFocus}>
+        <button
+          className={clsx('chevron', { hidden: item.children.length === 0 })}
+          onClick={handleChevronClick}
+          aria-label={collapsed ? 'Expand' : 'Collapse'}
+        >
+          {collapsed ? '▶' : '▼'}
+        </button>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={item.checked}
+            onChange={() => toggleChecked(id)}
+          />
+        </label>
+        <div
+          ref={textRef}
+          className="item-text"
+          contentEditable
+          suppressContentEditableWarning
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+          onFocus={updateCaret}
+          onBlur={updateCaret}
+          onCopy={handleCopy}
+          onPaste={handlePaste}
+          role="textbox"
+          aria-label="Item text"
+        />
+        {toolbar}
+      </div>
+      {noteOpen && (
+        <textarea
+          ref={noteRef}
+          className="item-note"
+          value={item.note ?? ''}
+          onChange={handleNoteChange}
+          onFocus={focusNote}
+          placeholder="Add note"
+        />
+      )}
+      {!collapsed && item.children.map((childId) => (
+        <ItemRow key={childId} id={childId} depth={depth + 1} />
+      ))}
+      <button
+        className="add-child"
+        onClick={handleAddChild}
+        onFocus={() => focusItem(id, undefined, 'subtree')}
+      >
+        Add child
+      </button>
+    </div>
+  );
+};
+
+const Outliner: React.FC = () => {
+  const rootIds = useOutlinerStore((state) => state.doc.rootIds);
+
+  const handleAddRoot = useCallback(() => {
+    const store = useOutlinerStore.getState();
+    const lastRoot = store.doc.rootIds[store.doc.rootIds.length - 1];
+    let newId: ItemId;
+    if (lastRoot) {
+      newId = store.addSiblingAfter(lastRoot);
+    } else {
+      const blankNode: ParsedNode = { text: '', checked: false, children: [] };
+      const created = store.insertNodes(undefined, undefined, [blankNode]);
+      newId = created[0];
+    }
+    requestAnimationFrame(() => store.focusItem(newId, 0, 'caret'));
+  }, []);
+
+  return (
+    <div className="outliner">
+      {rootIds.map((rootId) => (
+        <ItemRow key={rootId} id={rootId} depth={0} />
+      ))}
+      <button className="add-root" onClick={handleAddRoot}>Add top-level item</button>
+    </div>
+  );
+};
+
+export default Outliner;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,405 @@
+import { create } from 'zustand';
+import { produce } from 'immer';
+import { DocSnapshot, Item, ItemId, OutlinerState } from './types';
+import { createId } from './utils/id';
+import { ParsedNode } from './utils/markdown';
+
+const STORAGE_KEY = 'outliner:doc:v1';
+const TYPING_COALESCE_MS = 500;
+
+type DocUpdater = (draft: DocSnapshot) => void;
+
+interface OutlinerActions {
+  focusItem: (id: ItemId, caretOffset?: number, mode?: 'caret' | 'item' | 'subtree') => void;
+  toggleCollapse: (id: ItemId) => void;
+  toggleCollapseDeep: (id: ItemId, collapsed: boolean) => void;
+  toggleChecked: (id: ItemId) => void;
+  toggleNote: (id: ItemId) => void;
+  setText: (id: ItemId, text: string, opts?: { typing?: boolean; caretOffset?: number }) => void;
+  setNote: (id: ItemId, note: string) => void;
+  addSiblingAfter: (id: ItemId) => ItemId;
+  addChild: (id: ItemId) => ItemId;
+  deleteItem: (id: ItemId) => void;
+  moveUp: (id: ItemId) => void;
+  moveDown: (id: ItemId) => void;
+  indent: (id: ItemId) => void;
+  outdent: (id: ItemId) => void;
+  undo: () => void;
+  redo: () => void;
+  replaceDoc: (doc: DocSnapshot) => void;
+  insertNodes: (
+    parentId: ItemId | undefined,
+    afterId: ItemId | undefined,
+    nodes: ParsedNode[]
+  ) => ItemId[];
+}
+
+export type OutlinerStore = OutlinerState & OutlinerActions;
+
+const emptyDoc = (): DocSnapshot => {
+  const id = createId();
+  const item: Item = {
+    id,
+    text: 'New item',
+    checked: false,
+    children: [],
+  };
+  return { rootIds: [id], items: { [id]: item } };
+};
+
+const initialDoc = (): DocSnapshot => {
+  if (typeof localStorage === 'undefined') {
+    return emptyDoc();
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyDoc();
+    const parsed = JSON.parse(raw) as DocSnapshot;
+    if (!parsed.rootIds || !parsed.items) return emptyDoc();
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored doc', error);
+    return emptyDoc();
+  }
+};
+
+const createHistory = (doc: DocSnapshot) => ({
+  past: [] as DocSnapshot[],
+  present: doc,
+  future: [] as DocSnapshot[],
+  lastTextChange: undefined as number | undefined,
+});
+
+const persistDoc = (doc: DocSnapshot) => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(doc));
+};
+
+const ensureSelection = (
+  state: OutlinerStore,
+  id: ItemId,
+  caretOffset?: number,
+  mode: 'caret' | 'item' | 'subtree' = 'caret'
+) => {
+  state.ui.selection = { anchorId: id, mode, caretOffset };
+};
+
+const applyDocChange = (set: (fn: (state: OutlinerStore) => void) => void, get: () => OutlinerStore) =>
+  (updater: DocUpdater, opts?: { typing?: boolean; caretOffset?: number }) => {
+    const now = Date.now();
+    set((state) => {
+      const current = state.history.present;
+      const updated = produce(current, updater);
+      const shouldCoalesce = Boolean(opts?.typing) &&
+        state.history.lastTextChange !== undefined &&
+        now - state.history.lastTextChange < TYPING_COALESCE_MS;
+      if (shouldCoalesce) {
+        state.history.present = updated;
+        state.doc = updated;
+        state.history.lastTextChange = now;
+      } else {
+        state.history.past.push(current);
+        state.history.present = updated;
+        state.doc = updated;
+        state.history.future = [];
+        state.history.lastTextChange = opts?.typing ? now : undefined;
+      }
+      if (state.ui.selection && opts?.caretOffset !== undefined) {
+        state.ui.selection.caretOffset = opts.caretOffset;
+      }
+    });
+    persistDoc(get().doc);
+  };
+
+const insertAfterSibling = (doc: DocSnapshot, parentId: ItemId | undefined, siblingId: ItemId | undefined, id: ItemId) => {
+  if (parentId) {
+    const parent = doc.items[parentId];
+    const idx = siblingId ? parent.children.indexOf(siblingId) : -1;
+    parent.children.splice(idx + 1, 0, id);
+  } else {
+    const idx = siblingId ? doc.rootIds.indexOf(siblingId) : -1;
+    doc.rootIds.splice(idx + 1, 0, id);
+  }
+};
+
+const appendParsedNodes = (
+  draft: DocSnapshot,
+  parentId: ItemId | undefined,
+  afterId: ItemId | undefined,
+  nodes: ParsedNode[]
+): ItemId[] => {
+  const createdIds: ItemId[] = [];
+  const insertChild = (parent: ItemId, node: ParsedNode): ItemId => {
+    const id = createId();
+    const item: Item = {
+      id,
+      text: node.text,
+      checked: node.checked,
+      note: node.note,
+      children: [],
+      parentId: parent,
+    };
+    draft.items[id] = item;
+    node.children.forEach((child) => {
+      const childId = insertChild(id, child);
+      draft.items[id].children.push(childId);
+    });
+    return id;
+  };
+
+  let lastInserted = afterId;
+
+  const insertNode = (node: ParsedNode): ItemId => {
+    const id = createId();
+    const item: Item = {
+      id,
+      text: node.text,
+      checked: node.checked,
+      note: node.note,
+      children: [],
+      parentId,
+    };
+    draft.items[id] = item;
+    if (parentId) {
+      const parent = draft.items[parentId];
+      const siblings = parent.children;
+      const idx = lastInserted ? siblings.indexOf(lastInserted) : -1;
+      siblings.splice(idx + 1, 0, id);
+    } else {
+      const siblings = draft.rootIds;
+      const idx = lastInserted ? siblings.indexOf(lastInserted) : -1;
+      siblings.splice(idx + 1, 0, id);
+    }
+    lastInserted = id;
+    node.children.forEach((child) => {
+      const childId = insertChild(item.id, child);
+      draft.items[item.id].children.push(childId);
+    });
+    return id;
+  };
+
+  nodes.forEach((node) => {
+    const id = insertNode(node);
+    createdIds.push(id);
+  });
+
+  return createdIds;
+};
+
+export const useOutlinerStore = create<OutlinerStore>()((set, get) => {
+  const doc = initialDoc();
+  const history = createHistory(doc);
+  const apply = applyDocChange(set, get);
+
+  return {
+    doc,
+    ui: { collapsed: {}, notesOpen: {}, selection: undefined },
+    history,
+    focusItem: (id, caretOffset, mode = 'caret') => {
+      set((state) => {
+        state.ui.selection = { anchorId: id, mode, caretOffset };
+      });
+    },
+    toggleCollapse: (id) => {
+      set((state) => {
+        state.ui.collapsed[id] = !state.ui.collapsed[id];
+      });
+      persistDoc(get().doc);
+    },
+    toggleCollapseDeep: (id, collapsed) => {
+      set((state) => {
+        const traverse = (itemId: ItemId) => {
+          state.ui.collapsed[itemId] = collapsed;
+          state.doc.items[itemId].children.forEach(traverse);
+        };
+        traverse(id);
+      });
+      persistDoc(get().doc);
+    },
+    toggleChecked: (id) => {
+      apply((draft) => {
+        draft.items[id].checked = !draft.items[id].checked;
+      });
+    },
+    toggleNote: (id) => {
+      set((state) => {
+        state.ui.notesOpen[id] = !state.ui.notesOpen[id];
+      });
+      if (get().ui.notesOpen[id] && !get().doc.items[id].note) {
+        apply((draft) => {
+          draft.items[id].note = '';
+        });
+      }
+      persistDoc(get().doc);
+    },
+    setText: (id, text, opts) => {
+      apply((draft) => {
+        draft.items[id].text = text;
+      }, { typing: opts?.typing, caretOffset: opts?.caretOffset });
+    },
+    setNote: (id, note) => {
+      apply((draft) => {
+        draft.items[id].note = note;
+      });
+    },
+    addSiblingAfter: (id) => {
+      const newId = createId();
+      apply((draft) => {
+        const current = draft.items[id];
+        const siblingParent = current.parentId;
+        const item: Item = {
+          id: newId,
+          text: '',
+          checked: false,
+          children: [],
+          parentId: siblingParent,
+        };
+        draft.items[newId] = item;
+        insertAfterSibling(draft, siblingParent, id, newId);
+      });
+      ensureSelection(get(), newId, 0);
+      persistDoc(get().doc);
+      return newId;
+    },
+    addChild: (id) => {
+      const newId = createId();
+      apply((draft) => {
+        const item: Item = {
+          id: newId,
+          text: '',
+          checked: false,
+          children: [],
+          parentId: id,
+        };
+        draft.items[newId] = item;
+        draft.items[id].children.push(newId);
+      });
+      set((state) => {
+        state.ui.collapsed[id] = false;
+      });
+      ensureSelection(get(), newId, 0);
+      persistDoc(get().doc);
+      return newId;
+    },
+    deleteItem: (id) => {
+      apply((draft) => {
+        const queue = [id];
+        const toRemove = new Set<ItemId>();
+        while (queue.length) {
+          const currentId = queue.pop()!;
+          const item = draft.items[currentId];
+          if (!item) continue;
+          toRemove.add(currentId);
+          queue.push(...item.children);
+        }
+        toRemove.forEach((removeId) => {
+          const item = draft.items[removeId];
+          if (!item) return;
+          if (item.parentId) {
+            const parent = draft.items[item.parentId];
+            parent.children = parent.children.filter((childId) => childId !== removeId);
+          } else {
+            draft.rootIds = draft.rootIds.filter((rootId) => rootId !== removeId);
+          }
+          delete draft.items[removeId];
+        });
+      });
+    },
+    moveUp: (id) => {
+      apply((draft) => {
+        const item = draft.items[id];
+        const siblings = item.parentId ? draft.items[item.parentId].children : draft.rootIds;
+        const idx = siblings.indexOf(id);
+        if (idx > 0) {
+          [siblings[idx - 1], siblings[idx]] = [siblings[idx], siblings[idx - 1]];
+        }
+      });
+    },
+    moveDown: (id) => {
+      apply((draft) => {
+        const item = draft.items[id];
+        const siblings = item.parentId ? draft.items[item.parentId].children : draft.rootIds;
+        const idx = siblings.indexOf(id);
+        if (idx >= 0 && idx < siblings.length - 1) {
+          [siblings[idx + 1], siblings[idx]] = [siblings[idx], siblings[idx + 1]];
+        }
+      });
+    },
+    indent: (id) => {
+      apply((draft) => {
+        const item = draft.items[id];
+        const siblings = item.parentId ? draft.items[item.parentId].children : draft.rootIds;
+        const idx = siblings.indexOf(id);
+        if (idx > 0) {
+          const newParentId = siblings[idx - 1];
+          siblings.splice(idx, 1);
+          item.parentId = newParentId;
+          draft.items[newParentId].children.push(id);
+        }
+      });
+    },
+    outdent: (id) => {
+      apply((draft) => {
+        const item = draft.items[id];
+        if (!item.parentId) return;
+        const parent = draft.items[item.parentId];
+        const siblings = parent.children;
+        const idx = siblings.indexOf(id);
+        if (idx === -1) return;
+        siblings.splice(idx, 1);
+        const grandParentId = parent.parentId;
+        item.parentId = grandParentId;
+        if (grandParentId) {
+          const grandParent = draft.items[grandParentId];
+          const parentIdx = grandParent.children.indexOf(parent.id);
+          grandParent.children.splice(parentIdx + 1, 0, id);
+        } else {
+          const parentIdx = draft.rootIds.indexOf(parent.id);
+          draft.rootIds.splice(parentIdx + 1, 0, id);
+        }
+      });
+    },
+    undo: () => {
+      set((state) => {
+        if (!state.history.past.length) return;
+        const previous = state.history.past.pop()!;
+        state.history.future.unshift(state.history.present);
+        state.history.present = previous;
+        state.doc = previous;
+        state.history.lastTextChange = undefined;
+      });
+      persistDoc(get().doc);
+    },
+    redo: () => {
+      set((state) => {
+        if (!state.history.future.length) return;
+        const next = state.history.future.shift()!;
+        state.history.past.push(state.history.present);
+        state.history.present = next;
+        state.doc = next;
+        state.history.lastTextChange = undefined;
+      });
+      persistDoc(get().doc);
+    },
+    replaceDoc: (doc) => {
+      set((state) => {
+        state.history.past.push(state.history.present);
+        state.history.present = doc;
+        state.history.future = [];
+        state.history.lastTextChange = undefined;
+        state.doc = doc;
+      });
+      persistDoc(get().doc);
+    },
+    insertNodes: (parentId, afterId, nodes) => {
+      let created: ItemId[] = [];
+      apply((draft) => {
+        created = appendParsedNodes(draft, parentId, afterId, nodes);
+      });
+      if (created.length) {
+        ensureSelection(get(), created[created.length - 1], 0);
+      }
+      return created;
+    },
+  };
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,197 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+button {
+  font: inherit;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 120px;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 28px;
+  color: #102a43;
+}
+
+.tagline {
+  margin-top: 4px;
+  color: #52606d;
+}
+
+.outliner {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-row {
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 4px 8px;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
+}
+
+.item-row:hover {
+  background-color: rgba(15, 23, 42, 0.05);
+}
+
+.item-row.active {
+  background-color: rgba(59, 130, 246, 0.08);
+}
+
+.chevron {
+  border: none;
+  background: none;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  color: #334155;
+}
+
+.chevron.hidden {
+  visibility: hidden;
+}
+
+.checkbox input {
+  width: 20px;
+  height: 20px;
+}
+
+.item-text {
+  flex: 1;
+  min-height: 28px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  outline: none;
+  cursor: text;
+}
+
+.item-text:focus {
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.3);
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+.item-text strong {
+  font-weight: 700;
+}
+
+.item-text em {
+  font-style: italic;
+}
+
+.item-text code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  background-color: rgba(15, 23, 42, 0.08);
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
+.item-toolbar {
+  display: none;
+  align-items: center;
+  gap: 4px;
+  margin-left: 12px;
+}
+
+.item-row:hover .item-toolbar,
+.item-row:focus-within .item-toolbar {
+  display: flex;
+}
+
+.item-toolbar button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+}
+
+.item-toolbar button:hover {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.item-note {
+  margin-left: 56px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(226, 232, 240, 0.5);
+  font: inherit;
+  min-height: 64px;
+}
+
+.add-child,
+.add-root {
+  align-self: flex-start;
+  margin-left: 56px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: #1f2937;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.add-child:hover,
+.add-root:hover {
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.add-root {
+  margin-top: 16px;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 24px 16px 80px;
+  }
+
+  .item-row {
+    padding: 6px;
+  }
+
+  .item-toolbar {
+    display: flex;
+    margin-left: 8px;
+  }
+
+  .item-toolbar button {
+    width: 32px;
+    height: 32px;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,40 @@
+export type ItemId = string;
+
+export interface Item {
+  id: ItemId;
+  text: string;
+  checked: boolean;
+  note?: string;
+  children: ItemId[];
+  parentId?: ItemId;
+}
+
+export interface DocSnapshot {
+  rootIds: ItemId[];
+  items: Record<ItemId, Item>;
+}
+
+export interface SelectionState {
+  anchorId: ItemId;
+  mode: 'caret' | 'item' | 'subtree';
+  caretOffset?: number;
+}
+
+export interface UIState {
+  collapsed: Record<ItemId, boolean>;
+  selection?: SelectionState;
+  notesOpen: Record<ItemId, boolean>;
+}
+
+export interface HistoryState {
+  past: DocSnapshot[];
+  present: DocSnapshot;
+  future: DocSnapshot[];
+  lastTextChange?: number;
+}
+
+export interface OutlinerState {
+  doc: DocSnapshot;
+  ui: UIState;
+  history: HistoryState;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,15 @@
+const escapeHtml = (str: string) =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+export const renderInlineMarkdown = (text: string): string => {
+  const escaped = escapeHtml(text);
+  const code = escaped.replace(/`([^`]+)`/g, '<code>$1</code>');
+  const bold = code.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  const italic = bold.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+  return italic.replace(/\n/g, '<br/>');
+};

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,6 @@
+export const createId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `item_${Math.random().toString(36).slice(2, 10)}`;
+};

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,92 @@
+import { DocSnapshot, ItemId } from '../types';
+
+export interface ParsedNode {
+  text: string;
+  checked: boolean;
+  note?: string;
+  children: ParsedNode[];
+}
+
+const indent = (depth: number) => '  '.repeat(depth);
+
+const formatNote = (depth: number, note?: string) => {
+  if (!note) return [] as string[];
+  const lines = note.split('\n');
+  return lines.map((line) => `${indent(depth + 1)}${line}`);
+};
+
+export const serializeMarkdown = (doc: DocSnapshot, rootId: ItemId): string => {
+  const lines: string[] = [];
+  const visit = (id: ItemId, depth: number) => {
+    const item = doc.items[id];
+    const checkbox = item.checked ? '[x]' : '[ ]';
+    const text = item.text || '';
+    lines.push(`${indent(depth)}- ${checkbox} ${text}`.trimEnd());
+    lines.push(...formatNote(depth, item.note));
+    item.children.forEach((childId) => visit(childId, depth + 1));
+  };
+  visit(rootId, 0);
+  return lines.join('\n');
+};
+
+interface LineInfo {
+  indent: number;
+  text: string;
+  bullet?: boolean;
+  checked?: boolean;
+}
+
+const parseLine = (line: string): LineInfo => {
+  const expanded = line.replace(/\t/g, '  ');
+  const match = expanded.match(/^(\s*)([-*+]\s+)(\[(.|\s)\]\s+)?(.*)$/);
+  if (match) {
+    const spaces = match[1].length;
+    const checkbox = match[3]?.trim();
+    let checked: boolean | undefined;
+    if (checkbox === '[x]' || checkbox === '[X]') checked = true;
+    if (checkbox === '[ ]' || checkbox === '[]') checked = false;
+    const remaining = match[4] ?? '';
+    return {
+      indent: Math.floor(spaces / 2),
+      text: remaining.trim(),
+      bullet: true,
+      checked,
+    };
+  }
+  return {
+    indent: Math.floor((expanded.match(/^\s*/)![0].length) / 2),
+    text: expanded.trimEnd(),
+    bullet: false,
+  };
+};
+
+export const parseMarkdown = (markdown: string): ParsedNode[] => {
+  const lines = markdown.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const stack: { depth: number; node: ParsedNode }[] = [];
+  const roots: ParsedNode[] = [];
+
+  lines.forEach((line) => {
+    const info = parseLine(line);
+    if (info.bullet) {
+      const node: ParsedNode = {
+        text: info.text,
+        checked: info.checked ?? false,
+        children: [],
+      };
+      while (stack.length && stack[stack.length - 1].depth >= info.indent) {
+        stack.pop();
+      }
+      if (stack.length === 0) {
+        roots.push(node);
+      } else {
+        stack[stack.length - 1].node.children.push(node);
+      }
+      stack.push({ depth: info.indent, node });
+    } else if (stack.length) {
+      const target = stack[stack.length - 1].node;
+      target.note = target.note ? `${target.note}\n${info.text.trim()}` : info.text.trim();
+    }
+  });
+
+  return roots;
+};

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -1,0 +1,61 @@
+export const getCaretOffset = (element: HTMLElement): number => {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return 0;
+  const range = selection.getRangeAt(0);
+  const preRange = range.cloneRange();
+  preRange.selectNodeContents(element);
+  preRange.setEnd(range.endContainer, range.endOffset);
+  return preRange.toString().length;
+};
+
+export const getSelectionOffsets = (element: HTMLElement): { start: number; end: number } | null => {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.commonAncestorContainer)) return null;
+  const preRange = range.cloneRange();
+  preRange.selectNodeContents(element);
+  preRange.setEnd(range.startContainer, range.startOffset);
+  const start = preRange.toString().length;
+
+  const endRange = range.cloneRange();
+  const preEnd = endRange.cloneRange();
+  preEnd.selectNodeContents(element);
+  preEnd.setEnd(range.endContainer, range.endOffset);
+  const end = preEnd.toString().length;
+  return { start, end };
+};
+
+export const setCaretOffset = (element: HTMLElement, offset: number) => {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  let remaining = offset;
+
+  const traverse = (node: Node): Range | null => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const textLength = (node.textContent ?? '').length;
+      if (remaining <= textLength) {
+        range.setStart(node, remaining);
+        range.collapse(true);
+        return range;
+      }
+      remaining -= textLength;
+      return null;
+    }
+    const childNodes = Array.from(node.childNodes);
+    for (const child of childNodes) {
+      const result = traverse(child);
+      if (result) return result;
+    }
+    return null;
+  };
+
+  const finalRange = traverse(element);
+  if (finalRange) {
+    selection.removeAllRanges();
+    selection.addRange(finalRange);
+  } else {
+    element.focus();
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- implement a Zustand-powered document store with undo/redo, structural edits, and Markdown import/export support
- build the interactive React outline UI with keyboard shortcuts, formatting toolbar, notes, and subtree controls
- add styling, utilities, and documentation describing the local-first workflow and shortcuts

## Testing
- npm install *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68dae305e7888332b9be2eefcd82fcb9