### PR TITLE
Rewrite outliner without external deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# outliner-like-workflowy
+# Outline MVP
+
+A local-first outlining app inspired by Workflowy. The MVP is implemented with vanilla JavaScript and browser APIs, persisting data in `localStorage` so it works entirely offline without external build tooling.
+
+## Features
+
+- Infinite nested outline with checkbox-based tasks.
+- Keyboard-first controls for adding siblings/children, indenting, moving, and toggling completion or notes.
+- Inline Markdown formatting with bold, italic, and code styling that round-trips via clipboard.
+- Notes per item rendered in lightweight editor surfaces with quick toggles.
+- Undo/redo history with typing coalescing and structural snapshotting.
+- Markdown copy/paste for full subtree export/import.
+- Local persistence with instant restore on reload.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+`npm install` succeeds without network access because all dependencies are bundled locally. Running `npm run dev` starts a small Node-based static server on port 5173; alternatively, open `index.html` directly in your browser.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| Enter | New sibling |
+| Shift+Enter | Toggle note and focus note |
+| Tab / Shift+Tab | Indent / Outdent |
+| Alt+↑ / Alt+↓ | Move item up/down |
+| Cmd/Ctrl+. | Toggle checkbox |
+| Cmd/Ctrl+; | Toggle note |
+| Cmd/Ctrl+B | Bold selection |
+| Cmd/Ctrl+I | Italic selection |
+| Cmd/Ctrl+` | Inline code |
+| Cmd/Ctrl+Z / Shift+Cmd/Ctrl+Z / Cmd/Ctrl+Y | Undo / Redo |
+| Cmd/Ctrl+C / Cmd/Ctrl+V | Copy / Paste subtree as Markdown |
+
+## Clipboard Format
+
+Copying an item places Markdown of the entire subtree onto the clipboard, e.g.:
+
+```
+- [x] Complete outline
+  - [ ] Polish styling
+    Note for this item
+```
+
+Pasting Markdown with checkboxes reproduces the nested structure in the outline. Non-Markdown text is inserted into the current item.
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Outline</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "outliner-like-workflowy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "outliner-like-workflowy",
+      "version": "0.1.0",
+      "devDependencies": {}
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "outliner-like-workflowy",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node scripts/dev-server.js",
+    "start": "node scripts/dev-server.js"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -1,0 +1,62 @@
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const port = Number(process.env.PORT || 5173);
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+function sendNotFound(res) {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Not Found');
+}
+
+async function serveFile(res, filePath) {
+  try {
+    const stats = await stat(filePath);
+    if (stats.isDirectory()) {
+      return false;
+    }
+    const ext = path.extname(filePath);
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    createReadStream(filePath).pipe(res);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = req.url ? decodeURI(req.url.split('?')[0]) : '/';
+  const targetPath = path.join(rootDir, requestUrl);
+
+  if (await serveFile(res, targetPath)) {
+    return;
+  }
+
+  const indexPath = path.join(rootDir, 'index.html');
+  try {
+    const html = await readFile(indexPath);
+    res.writeHead(200, { 'Content-Type': MIME_TYPES['.html'] });
+    res.end(html);
+  } catch (error) {
+    sendNotFound(res);
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Dev server running at http://localhost:${port}`);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,505 @@
+import { createStore } from './store.js';
+import { renderInlineMarkdown } from './utils/format.js';
+import { getCaretOffset, getSelectionOffsets, setCaretOffset } from './utils/selection.js';
+import { parseMarkdown, serializeMarkdown } from './utils/markdown.js';
+
+const store = createStore();
+const root = document.getElementById('root');
+
+const refs = {
+  text: new Map(),
+  note: new Map(),
+  add: new Map(),
+};
+
+function formatSelection(value, selection, marker) {
+  const { start, end } = selection;
+  if (start === end) return null;
+  const before = value.slice(0, start);
+  const middle = value.slice(start, end);
+  const after = value.slice(end);
+  const markerPair = marker === '`' ? '`' : marker;
+  return {
+    text: `${before}${marker}${middle}${markerPair}${after}`,
+    selectionOffset: end + marker.length + markerPair.length,
+  };
+}
+
+function applySelectionFocus() {
+  const { ui, doc } = store.getState();
+  const selection = ui.selection;
+  if (!selection) return;
+  if (selection.mode === 'caret') {
+    const target = refs.text.get(selection.anchorId);
+    if (target) {
+      const offset = typeof selection.caretOffset === 'number'
+        ? selection.caretOffset
+        : (doc.items[selection.anchorId]?.text.length ?? 0);
+      target.focus({ preventScroll: true });
+      setCaretOffset(target, offset);
+    }
+  } else if (selection.mode === 'item') {
+    const note = refs.note.get(selection.anchorId);
+    if (note) {
+      note.focus({ preventScroll: true });
+      note.selectionStart = note.selectionEnd = note.value.length;
+    }
+  } else if (selection.mode === 'subtree') {
+    const button = refs.add.get(selection.anchorId);
+    if (button) {
+      button.focus({ preventScroll: true });
+    }
+  }
+}
+
+function handleFormatting(id, marker) {
+  const element = refs.text.get(id);
+  if (!element) return;
+  const offsets = getSelectionOffsets(element);
+  const text = element.innerText;
+  const selection = offsets && offsets.start !== offsets.end
+    ? offsets
+    : { start: 0, end: text.length };
+  const formatted = formatSelection(text, selection, marker);
+  if (formatted) {
+    store.setText(id, formatted.text, { caretOffset: formatted.selectionOffset });
+    requestAnimationFrame(() => {
+      const target = refs.text.get(id);
+      if (target) {
+        setCaretOffset(target, formatted.selectionOffset);
+      }
+    });
+  }
+}
+
+function focusAfterRender(callback) {
+  requestAnimationFrame(callback);
+}
+
+function createToolbar(id) {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'item-toolbar';
+
+  const makeButton = (label, title, handler) => {
+    const button = document.createElement('button');
+    button.innerHTML = label;
+    button.title = title;
+    button.addEventListener('click', (event) => {
+      event.stopPropagation();
+      handler();
+    });
+    return button;
+  };
+
+  toolbar.appendChild(makeButton('↑', 'Move up (Alt+↑)', () => store.moveUp(id)));
+  toolbar.appendChild(makeButton('↓', 'Move down (Alt+↓)', () => store.moveDown(id)));
+  toolbar.appendChild(makeButton('→', 'Indent (Tab)', () => store.indent(id)));
+  toolbar.appendChild(makeButton('←', 'Outdent (Shift+Tab)', () => store.outdent(id)));
+  toolbar.appendChild(makeButton('<strong>B</strong>', 'Bold (Cmd/Ctrl+B)', () => handleFormatting(id, '**')));
+  toolbar.appendChild(makeButton('<em>I</em>', 'Italic (Cmd/Ctrl+I)', () => handleFormatting(id, '*')));
+  toolbar.appendChild(makeButton('<code>&lt;</code>', 'Code (Cmd/Ctrl+`)', () => handleFormatting(id, '`')));
+  toolbar.appendChild(makeButton('+', 'Add child', () => {
+    const childId = store.addChild(id);
+    focusAfterRender(() => {
+      const child = refs.text.get(childId);
+      if (child) {
+        child.focus({ preventScroll: true });
+        setCaretOffset(child, 0);
+      }
+    });
+  }));
+  toolbar.appendChild(makeButton('📝', 'Toggle note (Cmd/Ctrl+;)', () => {
+    const isOpen = store.getState().ui.notesOpen[id];
+    store.toggleNote(id);
+    if (!isOpen) {
+      focusAfterRender(() => {
+        const note = refs.note.get(id);
+        if (note) {
+          note.focus({ preventScroll: true });
+          note.selectionStart = note.selectionEnd = note.value.length;
+        }
+      });
+    }
+  }));
+  toolbar.appendChild(makeButton('✕', 'Delete', () => {
+    store.deleteItem(id);
+  }));
+
+  return toolbar;
+}
+
+function handleCopy(event, id) {
+  event.preventDefault();
+  const markdown = serializeMarkdown(store.getState().doc, id);
+  event.clipboardData.setData('text/plain', markdown);
+  event.clipboardData.setData('text/markdown', markdown);
+}
+
+function handlePaste(event, id) {
+  const data = event.clipboardData.getData('text/markdown') || event.clipboardData.getData('text/plain');
+  if (!data) return;
+  const parsed = parseMarkdown(data);
+  if (!parsed.length) return;
+  event.preventDefault();
+  const { doc, ui } = store.getState();
+  const item = doc.items[id];
+  if (!item) return;
+  if (ui.selection?.mode === 'subtree') {
+    const lastChild = item.children[item.children.length - 1];
+    store.insertNodes(id, lastChild, parsed);
+  } else {
+    store.insertNodes(item.parentId, id, parsed);
+  }
+}
+
+function handleBackspace(event, id, textElement) {
+  if (!textElement) return;
+  const text = textElement.innerText.trim();
+  const { doc } = store.getState();
+  const item = doc.items[id];
+  if (!item) return;
+  if (text.length === 0 && item.children.length === 0) {
+    event.preventDefault();
+    let targetId;
+    const seekLastDescendant = (startId) => {
+      let currentId = startId;
+      while (doc.items[currentId]?.children.length) {
+        const children = doc.items[currentId].children;
+        currentId = children[children.length - 1];
+      }
+      return currentId;
+    };
+    if (item.parentId) {
+      const siblings = doc.items[item.parentId].children;
+      const idx = siblings.indexOf(id);
+      if (idx > 0) {
+        targetId = seekLastDescendant(siblings[idx - 1]);
+      } else {
+        targetId = item.parentId;
+      }
+    } else {
+      const roots = doc.rootIds;
+      const idx = roots.indexOf(id);
+      if (idx > 0) {
+        targetId = seekLastDescendant(roots[idx - 1]);
+      }
+    }
+    const caretLength = targetId ? (doc.items[targetId]?.text.length ?? 0) : 0;
+    store.deleteItem(id);
+    if (targetId) {
+      store.focusItem(targetId, caretLength, 'caret');
+      focusAfterRender(() => {
+        const target = refs.text.get(targetId);
+        if (target) {
+          target.focus({ preventScroll: true });
+          setCaretOffset(target, caretLength);
+        }
+      });
+    }
+  }
+}
+
+function createItemRow(id, depth) {
+  const { doc, ui } = store.getState();
+  const item = doc.items[id];
+  if (!item) return document.createDocumentFragment();
+  const collapsed = Boolean(ui.collapsed[id]);
+  const noteOpen = ui.notesOpen[id] ?? Boolean(item.note);
+
+  const container = document.createElement('div');
+  container.className = 'item-container';
+  container.style.marginLeft = `${depth * 20}px`;
+
+  const row = document.createElement('div');
+  row.className = 'item-row';
+  if (ui.selection?.anchorId === id) {
+    row.classList.add('active');
+  }
+  row.addEventListener('click', () => {
+    store.focusItem(id, undefined, 'caret');
+  });
+
+  const chevron = document.createElement('button');
+  chevron.className = 'chevron';
+  chevron.textContent = collapsed ? '▶' : '▼';
+  if (item.children.length === 0) {
+    chevron.classList.add('hidden');
+  }
+  chevron.addEventListener('click', (event) => {
+    event.stopPropagation();
+    if (event.altKey) {
+      store.toggleCollapseDeep(id, !collapsed);
+    } else {
+      store.toggleCollapse(id);
+    }
+  });
+
+  const checkboxLabel = document.createElement('label');
+  checkboxLabel.className = 'checkbox';
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = item.checked;
+  checkbox.addEventListener('change', (event) => {
+    event.stopPropagation();
+    store.toggleChecked(id);
+  });
+  checkboxLabel.appendChild(checkbox);
+
+  const text = document.createElement('div');
+  text.className = 'item-text';
+  text.contentEditable = 'true';
+  text.innerHTML = renderInlineMarkdown(item.text);
+  text.setAttribute('role', 'textbox');
+  text.setAttribute('aria-label', 'Item text');
+  refs.text.set(id, text);
+
+  text.addEventListener('input', () => {
+    const caret = getCaretOffset(text);
+    store.setText(id, text.innerText, { typing: true, caretOffset: caret });
+  });
+
+  text.addEventListener('focus', () => {
+    const caret = getCaretOffset(text);
+    store.focusItem(id, caret, 'caret');
+  });
+
+  text.addEventListener('blur', () => {
+    const caret = getCaretOffset(text);
+    store.focusItem(id, caret, 'caret');
+  });
+
+  text.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (event.shiftKey) {
+        store.toggleNote(id);
+        focusAfterRender(() => {
+          const note = refs.note.get(id);
+          if (note) {
+            note.focus({ preventScroll: true });
+            note.selectionStart = note.selectionEnd = note.value.length;
+          }
+        });
+        return;
+      }
+      const newId = store.addSiblingAfter(id);
+      focusAfterRender(() => {
+        const next = refs.text.get(newId);
+        if (next) {
+          next.focus({ preventScroll: true });
+          setCaretOffset(next, 0);
+        }
+      });
+      return;
+    }
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      if (event.shiftKey) {
+        store.outdent(id);
+      } else {
+        store.indent(id);
+      }
+      return;
+    }
+    if (event.key === 'Backspace') {
+      handleBackspace(event, id, text);
+      return;
+    }
+    if (event.key === 'ArrowUp' && event.altKey) {
+      event.preventDefault();
+      store.moveUp(id);
+      return;
+    }
+    if (event.key === 'ArrowDown' && event.altKey) {
+      event.preventDefault();
+      store.moveDown(id);
+      return;
+    }
+    const lowerKey = event.key.toLowerCase();
+    if ((event.metaKey || event.ctrlKey) && lowerKey === 'b') {
+      event.preventDefault();
+      handleFormatting(id, '**');
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && lowerKey === 'i') {
+      event.preventDefault();
+      handleFormatting(id, '*');
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && event.key === '`') {
+      event.preventDefault();
+      handleFormatting(id, '`');
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && event.key === '.') {
+      event.preventDefault();
+      store.toggleChecked(id);
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && event.key === ';') {
+      event.preventDefault();
+      store.toggleNote(id);
+      focusAfterRender(() => {
+        const note = refs.note.get(id);
+        if (note) {
+          note.focus({ preventScroll: true });
+          note.selectionStart = note.selectionEnd = note.value.length;
+        }
+      });
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && lowerKey === 'd') {
+      event.preventDefault();
+      const newId = store.addSiblingAfter(id);
+      focusAfterRender(() => {
+        const next = refs.text.get(newId);
+        if (next) {
+          next.focus({ preventScroll: true });
+          setCaretOffset(next, 0);
+        }
+      });
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && (lowerKey === 'z' || lowerKey === 'y')) {
+      event.preventDefault();
+    }
+  });
+
+  text.addEventListener('copy', (event) => handleCopy(event, id));
+  text.addEventListener('cut', (event) => handleCopy(event, id));
+  text.addEventListener('paste', (event) => handlePaste(event, id));
+
+  const toolbar = createToolbar(id);
+
+  row.appendChild(chevron);
+  row.appendChild(checkboxLabel);
+  row.appendChild(text);
+  row.appendChild(toolbar);
+
+  container.appendChild(row);
+
+  if (noteOpen) {
+    const note = document.createElement('textarea');
+    note.className = 'item-note';
+    note.value = item.note ?? '';
+    note.placeholder = 'Add note';
+    refs.note.set(id, note);
+    note.addEventListener('change', (event) => {
+      store.setNote(id, event.target.value);
+    });
+    note.addEventListener('focus', () => {
+      store.focusItem(id, undefined, 'item');
+    });
+    container.appendChild(note);
+  }
+
+  if (!collapsed) {
+    item.children.forEach((childId) => {
+      container.appendChild(createItemRow(childId, depth + 1));
+    });
+  }
+
+  const addChildButton = document.createElement('button');
+  addChildButton.className = 'add-child';
+  addChildButton.textContent = 'Add child';
+  addChildButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    const childId = store.addChild(id);
+    focusAfterRender(() => {
+      const child = refs.text.get(childId);
+      if (child) {
+        child.focus({ preventScroll: true });
+        setCaretOffset(child, 0);
+      }
+    });
+  });
+  addChildButton.addEventListener('focus', () => {
+    store.focusItem(id, undefined, 'subtree');
+  });
+  refs.add.set(id, addChildButton);
+  container.appendChild(addChildButton);
+
+  return container;
+}
+
+function render() {
+  refs.text.clear();
+  refs.note.clear();
+  refs.add.clear();
+
+  root.innerHTML = '';
+
+  const app = document.createElement('div');
+  app.className = 'app-shell';
+
+  const header = document.createElement('header');
+  header.className = 'app-header';
+  const title = document.createElement('h1');
+  title.textContent = 'Outline';
+  const tagline = document.createElement('p');
+  tagline.className = 'tagline';
+  tagline.textContent = 'Fast, local-first outlining with keyboard superpowers.';
+  header.appendChild(title);
+  header.appendChild(tagline);
+
+  const main = document.createElement('main');
+  const outliner = document.createElement('div');
+  outliner.className = 'outliner';
+
+  const { doc } = store.getState();
+  doc.rootIds.forEach((rootId) => {
+    outliner.appendChild(createItemRow(rootId, 0));
+  });
+
+  const addRoot = document.createElement('button');
+  addRoot.className = 'add-root';
+  addRoot.textContent = 'Add top-level item';
+  addRoot.addEventListener('click', () => {
+    const state = store.getState();
+    const lastRoot = state.doc.rootIds[state.doc.rootIds.length - 1];
+    let newId;
+    if (lastRoot) {
+      newId = store.addSiblingAfter(lastRoot);
+    } else {
+      const blankNode = { text: '', checked: false, children: [] };
+      const created = store.insertNodes(undefined, undefined, [blankNode]);
+      newId = created[0];
+    }
+    focusAfterRender(() => {
+      const target = refs.text.get(newId);
+      if (target) {
+        target.focus({ preventScroll: true });
+        setCaretOffset(target, 0);
+      }
+    });
+  });
+
+  main.appendChild(outliner);
+  main.appendChild(addRoot);
+
+  app.appendChild(header);
+  app.appendChild(main);
+
+  root.appendChild(app);
+
+  applySelectionFocus();
+}
+
+store.subscribe(render);
+render();
+
+window.addEventListener('keydown', (event) => {
+  const key = event.key.toLowerCase();
+  if ((event.metaKey || event.ctrlKey) && key === 'z') {
+    event.preventDefault();
+    if (event.shiftKey) {
+      store.redo();
+    } else {
+      store.undo();
+    }
+  }
+  if ((event.metaKey || event.ctrlKey) && (key === 'y')) {
+    event.preventDefault();
+    store.redo();
+  }
+});

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,322 @@
+import { createId } from './utils/id.js';
+import { appendParsedNodes } from './utils/markdown.js';
+
+const STORAGE_KEY = 'outliner:doc:v1';
+const TYPING_COALESCE_MS = 500;
+
+function cloneDoc(doc) {
+  return JSON.parse(JSON.stringify(doc));
+}
+
+function emptyDoc() {
+  const id = createId();
+  const item = {
+    id,
+    text: 'New item',
+    checked: false,
+    children: [],
+  };
+  return { rootIds: [id], items: { [id]: item } };
+}
+
+function loadDoc() {
+  if (typeof localStorage === 'undefined') {
+    return emptyDoc();
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyDoc();
+    const parsed = JSON.parse(raw);
+    if (!parsed.rootIds || !parsed.items) return emptyDoc();
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored doc', error);
+    return emptyDoc();
+  }
+}
+
+function persistDoc(doc) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(doc));
+}
+
+function createHistory(doc) {
+  return {
+    past: [],
+    present: doc,
+    future: [],
+    lastTextChange: undefined,
+  };
+}
+
+export function createStore() {
+  const listeners = new Set();
+  const doc = loadDoc();
+  const state = {
+    doc,
+    ui: { collapsed: {}, notesOpen: {}, selection: undefined },
+    history: createHistory(doc),
+  };
+
+  const notify = () => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+
+  const getState = () => state;
+
+  const ensureSelection = (id, caretOffset, mode = 'caret') => {
+    state.ui.selection = { anchorId: id, caretOffset, mode };
+  };
+
+  const applyDocChange = (updater, opts = {}) => {
+    const now = Date.now();
+    const current = state.history.present;
+    const updated = cloneDoc(current);
+    updater(updated);
+    const shouldCoalesce = Boolean(opts.typing) &&
+      state.history.lastTextChange !== undefined &&
+      now - state.history.lastTextChange < TYPING_COALESCE_MS;
+
+    if (shouldCoalesce) {
+      state.history.present = updated;
+      state.doc = updated;
+      state.history.lastTextChange = now;
+    } else {
+      state.history.past.push(current);
+      state.history.present = updated;
+      state.doc = updated;
+      state.history.future = [];
+      state.history.lastTextChange = opts.typing ? now : undefined;
+    }
+
+    if (state.ui.selection && typeof opts.caretOffset === 'number') {
+      state.ui.selection.caretOffset = opts.caretOffset;
+    }
+
+    persistDoc(state.doc);
+    notify();
+  };
+
+  const store = {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getState,
+    focusItem(id, caretOffset, mode = 'caret') {
+      ensureSelection(id, caretOffset, mode);
+      notify();
+    },
+    toggleCollapse(id) {
+      state.ui.collapsed[id] = !state.ui.collapsed[id];
+      persistDoc(state.doc);
+      notify();
+    },
+    toggleCollapseDeep(id, collapsed) {
+      const traverse = (itemId) => {
+        state.ui.collapsed[itemId] = collapsed;
+        const item = state.doc.items[itemId];
+        if (item) {
+          item.children.forEach(traverse);
+        }
+      };
+      traverse(id);
+      persistDoc(state.doc);
+      notify();
+    },
+    toggleChecked(id) {
+      applyDocChange((draft) => {
+        draft.items[id].checked = !draft.items[id].checked;
+      });
+    },
+    toggleNote(id) {
+      state.ui.notesOpen[id] = !state.ui.notesOpen[id];
+      if (state.ui.notesOpen[id] && !state.doc.items[id].note) {
+        applyDocChange((draft) => {
+          draft.items[id].note = '';
+        });
+        return;
+      }
+      persistDoc(state.doc);
+      notify();
+    },
+    setText(id, text, opts = {}) {
+      applyDocChange((draft) => {
+        draft.items[id].text = text;
+      }, opts);
+    },
+    setNote(id, note) {
+      applyDocChange((draft) => {
+        draft.items[id].note = note;
+      });
+    },
+    addSiblingAfter(id) {
+      const newId = createId();
+      applyDocChange((draft) => {
+        const current = draft.items[id];
+        const siblingParent = current.parentId;
+        const item = {
+          id: newId,
+          text: '',
+          checked: false,
+          children: [],
+          parentId: siblingParent,
+        };
+        draft.items[newId] = item;
+        if (siblingParent) {
+          const parent = draft.items[siblingParent];
+          const idx = parent.children.indexOf(id);
+          parent.children.splice(idx + 1, 0, newId);
+        } else {
+          const idx = draft.rootIds.indexOf(id);
+          draft.rootIds.splice(idx + 1, 0, newId);
+        }
+      });
+      ensureSelection(newId, 0);
+      persistDoc(state.doc);
+      notify();
+      return newId;
+    },
+    addChild(id) {
+      const newId = createId();
+      applyDocChange((draft) => {
+        const item = {
+          id: newId,
+          text: '',
+          checked: false,
+          children: [],
+          parentId: id,
+        };
+        draft.items[newId] = item;
+        draft.items[id].children.push(newId);
+      });
+      state.ui.collapsed[id] = false;
+      ensureSelection(newId, 0);
+      persistDoc(state.doc);
+      notify();
+      return newId;
+    },
+    deleteItem(id) {
+      applyDocChange((draft) => {
+        const queue = [id];
+        const toRemove = new Set();
+        while (queue.length) {
+          const currentId = queue.pop();
+          const item = draft.items[currentId];
+          if (!item) continue;
+          toRemove.add(currentId);
+          queue.push(...item.children);
+        }
+        toRemove.forEach((removeId) => {
+          const item = draft.items[removeId];
+          if (!item) return;
+          if (item.parentId) {
+            const parent = draft.items[item.parentId];
+            parent.children = parent.children.filter((childId) => childId !== removeId);
+          } else {
+            draft.rootIds = draft.rootIds.filter((rootId) => rootId !== removeId);
+          }
+          delete draft.items[removeId];
+        });
+      });
+    },
+    moveUp(id) {
+      applyDocChange((draft) => {
+        const item = draft.items[id];
+        const siblings = item.parentId ? draft.items[item.parentId].children : draft.rootIds;
+        const idx = siblings.indexOf(id);
+        if (idx > 0) {
+          [siblings[idx - 1], siblings[idx]] = [siblings[idx], siblings[idx - 1]];
+        }
+      });
+    },
+    moveDown(id) {
+      applyDocChange((draft) => {
+        const item = draft.items[id];
+        const siblings = item.parentId ? draft.items[item.parentId].children : draft.rootIds;
+        const idx = siblings.indexOf(id);
+        if (idx >= 0 && idx < siblings.length - 1) {
+          [siblings[idx + 1], siblings[idx]] = [siblings[idx], siblings[idx + 1]];
+        }
+      });
+    },
+    indent(id) {
+      applyDocChange((draft) => {
+        const item = draft.items[id];
+        const siblings = item.parentId ? draft.items[item.parentId].children : draft.rootIds;
+        const idx = siblings.indexOf(id);
+        if (idx > 0) {
+          const newParentId = siblings[idx - 1];
+          siblings.splice(idx, 1);
+          item.parentId = newParentId;
+          draft.items[newParentId].children.push(id);
+        }
+      });
+    },
+    outdent(id) {
+      applyDocChange((draft) => {
+        const item = draft.items[id];
+        if (!item.parentId) return;
+        const parent = draft.items[item.parentId];
+        const siblings = parent.children;
+        const idx = siblings.indexOf(id);
+        if (idx === -1) return;
+        siblings.splice(idx, 1);
+        const grandParentId = parent.parentId;
+        item.parentId = grandParentId;
+        if (grandParentId) {
+          const grandParent = draft.items[grandParentId];
+          const parentIdx = grandParent.children.indexOf(parent.id);
+          grandParent.children.splice(parentIdx + 1, 0, id);
+        } else {
+          const parentIdx = draft.rootIds.indexOf(parent.id);
+          draft.rootIds.splice(parentIdx + 1, 0, id);
+        }
+      });
+    },
+    undo() {
+      if (!state.history.past.length) return;
+      const previous = state.history.past.pop();
+      state.history.future.unshift(state.history.present);
+      state.history.present = previous;
+      state.doc = previous;
+      state.history.lastTextChange = undefined;
+      persistDoc(state.doc);
+      notify();
+    },
+    redo() {
+      if (!state.history.future.length) return;
+      const next = state.history.future.shift();
+      state.history.past.push(state.history.present);
+      state.history.present = next;
+      state.doc = next;
+      state.history.lastTextChange = undefined;
+      persistDoc(state.doc);
+      notify();
+    },
+    replaceDoc(docSnapshot) {
+      state.history.past.push(state.history.present);
+      state.history.present = docSnapshot;
+      state.history.future = [];
+      state.history.lastTextChange = undefined;
+      state.doc = docSnapshot;
+      persistDoc(state.doc);
+      notify();
+    },
+    insertNodes(parentId, afterId, nodes) {
+      let created = [];
+      applyDocChange((draft) => {
+        created = appendParsedNodes(draft, parentId, afterId, nodes);
+      });
+      if (created.length) {
+        ensureSelection(created[created.length - 1], 0);
+        notify();
+      }
+      return created;
+    },
+  };
+
+  return store;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,197 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+button {
+  font: inherit;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 120px;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 28px;
+  color: #102a43;
+}
+
+.tagline {
+  margin-top: 4px;
+  color: #52606d;
+}
+
+.outliner {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-row {
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 4px 8px;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
+}
+
+.item-row:hover {
+  background-color: rgba(15, 23, 42, 0.05);
+}
+
+.item-row.active {
+  background-color: rgba(59, 130, 246, 0.08);
+}
+
+.chevron {
+  border: none;
+  background: none;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  color: #334155;
+}
+
+.chevron.hidden {
+  visibility: hidden;
+}
+
+.checkbox input {
+  width: 20px;
+  height: 20px;
+}
+
+.item-text {
+  flex: 1;
+  min-height: 28px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  outline: none;
+  cursor: text;
+}
+
+.item-text:focus {
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.3);
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+.item-text strong {
+  font-weight: 700;
+}
+
+.item-text em {
+  font-style: italic;
+}
+
+.item-text code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  background-color: rgba(15, 23, 42, 0.08);
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
+.item-toolbar {
+  display: none;
+  align-items: center;
+  gap: 4px;
+  margin-left: 12px;
+}
+
+.item-row:hover .item-toolbar,
+.item-row:focus-within .item-toolbar {
+  display: flex;
+}
+
+.item-toolbar button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+}
+
+.item-toolbar button:hover {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.item-note {
+  margin-left: 56px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(226, 232, 240, 0.5);
+  font: inherit;
+  min-height: 64px;
+}
+
+.add-child,
+.add-root {
+  align-self: flex-start;
+  margin-left: 56px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: #1f2937;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.add-child:hover,
+.add-root:hover {
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.add-root {
+  margin-top: 16px;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 24px 16px 80px;
+  }
+
+  .item-row {
+    padding: 6px;
+  }
+
+  .item-toolbar {
+    display: flex;
+    margin-left: 8px;
+  }
+
+  .item-toolbar button {
+    width: 32px;
+    height: 32px;
+  }
+}

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,23 @@
+const htmlEscapes = [
+  { regex: /&/g, replacement: '&amp;' },
+  { regex: /</g, replacement: '&lt;' },
+  { regex: />/g, replacement: '&gt;' },
+  { regex: /"/g, replacement: '&quot;' },
+  { regex: /'/g, replacement: '&#39;' },
+];
+
+function escapeHtml(str) {
+  let result = str;
+  for (const { regex, replacement } of htmlEscapes) {
+    result = result.replace(regex, replacement);
+  }
+  return result;
+}
+
+export function renderInlineMarkdown(text) {
+  const escaped = escapeHtml(text);
+  const code = escaped.replace(/`([^`]+)`/g, '<code>$1</code>');
+  const bold = code.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  const italic = bold.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+  return italic.replace(/\n/g, '<br/>');
+}

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,0 +1,6 @@
+export function createId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `item_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -1,0 +1,144 @@
+import { createId } from './id.js';
+
+const STORAGE_INDENT = 2;
+
+function indent(depth) {
+  return '  '.repeat(depth);
+}
+
+function formatNote(depth, note) {
+  if (!note) return [];
+  const lines = note.split('\n');
+  return lines.map((line) => `${indent(depth + 1)}${line}`);
+}
+
+export function serializeMarkdown(doc, rootId) {
+  const lines = [];
+  const visit = (id, depth) => {
+    const item = doc.items[id];
+    if (!item) return;
+    const checkbox = item.checked ? '[x]' : '[ ]';
+    const text = item.text || '';
+    lines.push(`${indent(depth)}- ${checkbox} ${text}`.trimEnd());
+    lines.push(...formatNote(depth, item.note));
+    item.children.forEach((childId) => visit(childId, depth + 1));
+  };
+  visit(rootId, 0);
+  return lines.join('\n');
+}
+
+function parseLine(line) {
+  const expanded = line.replace(/\t/g, '  ');
+  const match = expanded.match(/^(\s*)([-*+]\s+)(\[(.|\s)\]\s+)?(.*)$/);
+  if (match) {
+    const spaces = match[1].length;
+    const checkbox = match[3]?.trim();
+    let checked;
+    if (checkbox === '[x]' || checkbox === '[X]') checked = true;
+    if (checkbox === '[ ]' || checkbox === '[]') checked = false;
+    const remaining = match[4] ?? '';
+    return {
+      indent: Math.floor(spaces / STORAGE_INDENT),
+      text: remaining.trim(),
+      bullet: true,
+      checked,
+    };
+  }
+  const leadingSpaces = expanded.match(/^\s*/) ?? [''];
+  return {
+    indent: Math.floor((leadingSpaces[0].length) / STORAGE_INDENT),
+    text: expanded.trimEnd(),
+    bullet: false,
+  };
+}
+
+export function parseMarkdown(markdown) {
+  const lines = markdown.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const stack = [];
+  const roots = [];
+
+  lines.forEach((line) => {
+    const info = parseLine(line);
+    if (info.bullet) {
+      const node = {
+        text: info.text,
+        checked: info.checked ?? false,
+        children: [],
+      };
+      while (stack.length && stack[stack.length - 1].depth >= info.indent) {
+        stack.pop();
+      }
+      if (stack.length === 0) {
+        roots.push(node);
+      } else {
+        stack[stack.length - 1].node.children.push(node);
+      }
+      stack.push({ depth: info.indent, node });
+    } else if (stack.length) {
+      const target = stack[stack.length - 1].node;
+      target.note = target.note ? `${target.note}\n${info.text.trim()}` : info.text.trim();
+    }
+  });
+
+  return roots;
+}
+
+export function appendParsedNodes(doc, parentId, afterId, nodes) {
+  const createdIds = [];
+
+  const insertChild = (parent, node) => {
+    const id = createId();
+    const item = {
+      id,
+      text: node.text,
+      checked: node.checked,
+      note: node.note,
+      children: [],
+      parentId: parent,
+    };
+    doc.items[id] = item;
+    node.children.forEach((child) => {
+      const childId = insertChild(id, child);
+      doc.items[id].children.push(childId);
+    });
+    return id;
+  };
+
+  let lastInserted = afterId;
+
+  const insertNode = (node) => {
+    const id = createId();
+    const item = {
+      id,
+      text: node.text,
+      checked: node.checked,
+      note: node.note,
+      children: [],
+      parentId,
+    };
+    doc.items[id] = item;
+    if (parentId) {
+      const parent = doc.items[parentId];
+      const siblings = parent.children;
+      const idx = lastInserted ? siblings.indexOf(lastInserted) : -1;
+      siblings.splice(idx + 1, 0, id);
+    } else {
+      const siblings = doc.rootIds;
+      const idx = lastInserted ? siblings.indexOf(lastInserted) : -1;
+      siblings.splice(idx + 1, 0, id);
+    }
+    lastInserted = id;
+    node.children.forEach((child) => {
+      const childId = insertChild(id, child);
+      doc.items[id].children.push(childId);
+    });
+    return id;
+  };
+
+  nodes.forEach((node) => {
+    const id = insertNode(node);
+    createdIds.push(id);
+  });
+
+  return createdIds;
+}

--- a/src/utils/selection.js
+++ b/src/utils/selection.js
@@ -1,0 +1,61 @@
+export function getCaretOffset(element) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return 0;
+  const range = selection.getRangeAt(0);
+  const preRange = range.cloneRange();
+  preRange.selectNodeContents(element);
+  preRange.setEnd(range.endContainer, range.endOffset);
+  return preRange.toString().length;
+}
+
+export function getSelectionOffsets(element) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.commonAncestorContainer)) return null;
+  const preRange = range.cloneRange();
+  preRange.selectNodeContents(element);
+  preRange.setEnd(range.startContainer, range.startOffset);
+  const start = preRange.toString().length;
+
+  const endRange = range.cloneRange();
+  const preEnd = endRange.cloneRange();
+  preEnd.selectNodeContents(element);
+  preEnd.setEnd(range.endContainer, range.endOffset);
+  const end = preEnd.toString().length;
+  return { start, end };
+}
+
+export function setCaretOffset(element, offset) {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  let remaining = offset;
+
+  const traverse = (node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const textLength = (node.textContent ?? '').length;
+      if (remaining <= textLength) {
+        range.setStart(node, Math.max(0, remaining));
+        range.collapse(true);
+        return range;
+      }
+      remaining -= textLength;
+      return null;
+    }
+    const childNodes = Array.from(node.childNodes);
+    for (const child of childNodes) {
+      const result = traverse(child);
+      if (result) return result;
+    }
+    return null;
+  };
+
+  const finalRange = traverse(element);
+  if (finalRange) {
+    selection.removeAllRanges();
+    selection.addRange(finalRange);
+  } else {
+    element.focus();
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the outlining app in vanilla JavaScript with a custom store, DOM renderer, and markdown helpers to prevent runtime crashes
- replace React/Vite tooling with a dependency-free setup, including a lightweight Node static dev server and updated documentation
- keep clipboard formatting, keyboard controls, persistence, and styling while ensuring npm install succeeds offline

## Testing
- npm install
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dae305e7888332b9be2eefcd82fcb9